### PR TITLE
Add Twitter card related metadata to [slug].svelte

### DIFF
--- a/src/routes/blog/[slug].svelte
+++ b/src/routes/blog/[slug].svelte
@@ -42,6 +42,44 @@
 
 <svelte:head>
   <title>{post.title}</title>
+<!--  Include canonical links to your blog -->
+<!--   <link rel="canonical" href="" /> -->
+  
+<!-- Validate your twitter card with https://cards-dev.twitter.com/validator  -->
+<!-- Update content properties with your URL   -->
+<!-- 	<meta property="og:url" content=""} /> -->
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content={post.title} />
+	<meta name="Description" content={post.excerpt} />
+	<meta property="og:description" content={post.excerpt} />
+  
+<!--  Link to your preferred image  -->
+<!-- 	<meta property="og:image" content="" /> -->
+  
+	<meta name="twitter:card" content="summary_large_image" />
+  
+<!--  Link to your Domain  -->
+<!-- 	<meta name="twitter:domain" value="" /> -->
+  
+<!--  Link to your Twitter Account  -->
+<!-- 	<meta name="twitter:creator" value="" /> -->
+  
+	<meta name="twitter:title" value={post.title} />
+	<meta name="twitter:description" content={post.excerpt} />
+  
+<!--  Link to your preferred image to be displayed on Twitter (832x520px) -->
+<!-- 	<meta name="twitter:image" content="" /> -->
+  
+	<meta name="twitter:label1" value="Published on" />
+	<meta
+		name="twitter:data1"
+		value={new Date(post.printDate).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		})} />
+	<meta name="twitter:label2" value="Reading Time" />
+	<meta name="twitter:data2" value={post.printReadingTime} />
 </svelte:head>
 
 <header>


### PR DESCRIPTION
Hey Maxi, thanks a lot for a really awesome blog starter. I needed to add some metadata for twitter to render cards in the preview, so thought might be useful for others. 

Here's an example.
https://twitter.com/alanmynah/status/1321358353931636736?s=20