### PR TITLE
Remove superfluous information in alt tag

### DIFF
--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -24,7 +24,7 @@
 <div class="container">
   <h1>About</h1>
   <figure>
-    <img src='rsz_florian-klauer-489-unsplash.jpg' alt='Image of a vintage typewriter.'>
+    <img src='rsz_florian-klauer-489-unsplash.jpg' alt='A vintage typewriter.'>
     <figcaption>Photo by <a href="https://unsplash.com/@florianklauer" target="_blank">Florian Klauer</a> on Unsplash</figcaption>
   </figure>
   <p>Text placeholder via <a href="https://jeffsum.com/" target="_blank">Jeffsum</a>.</p>


### PR DESCRIPTION
This removes the warning in the console 
`A11y: Screenreaders already announce <img> elements as an image.`